### PR TITLE
Fix comment syntax

### DIFF
--- a/astar.js
+++ b/astar.js
@@ -152,9 +152,9 @@ var astar = {
 
 /**
 * A graph memory structure
-* @param {Array} gridIn: 2D array of input weights
-* @param {Object} options:
-*                  - diagonal: Specifies whether diagonal moves are allowed.
+* @param {Array} gridIn 2D array of input weights
+* @param {Object} [options]
+* @param {bool} [options.diagonal] Specifies whether diagonal moves are allowed
 */
 function Graph(gridIn, options) {
     options = options || {};


### PR DESCRIPTION
- `:` is not part of the parameter name
- Use one syntax for object with a known set of properties
