### PR TITLE
Latest commits not in 0.4.1 - Prep for 0.4.2 release

### DIFF
--- a/astar.js
+++ b/astar.js
@@ -1,4 +1,4 @@
-// javascript-astar 0.4.1
+// javascript-astar 0.4.2
 // http://github.com/bgrins/javascript-astar
 // Freely distributable under the MIT License.
 // Implements the astar search algorithm in javascript using a Binary Heap.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-astar",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "astar search algorithm in JavaScript",
   "main": "astar.js",
   "repository": {


### PR DESCRIPTION
I was reusing a graph to find multiple paths and hit the (closed) issue #43, which was fixed by the most recent commits. Those commits didn't make it into an npm release. Could you publish 0.4.2? I'm PR'ing the prep.